### PR TITLE
Add timeout to the docker command

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -78,8 +78,11 @@ async def check_submission(websocket:object, submission:dict):
 
     # Grade the submission inside the docker container "badkan"
     grade = None
-    proc = await docker_command(["exec", "-w", repository_folder, "badkan", "bash", "-c", 
-        "mv grading_files/* .; rm -rf grading_files; nice -n 5 ./grade {} {}".format(username,repository)])
+    move_command = "mv grading_files/* . && rm -rf grading_files"
+    grade_command = "timeout -s 9 10 timeout 5 nice -n 5 ./grade {} {}".format(username,repository)
+    combined_command = "{} && {}".format(move_command, grade_command)
+    proc = await docker_command(["exec", "-w", repository_folder, "badkan", "bash", "-c", combined_command])
+
     async for line in proc.stdout:
         line = line.decode('utf-8').strip()
         await tee(websocket, line)

--- a/backend/server.py
+++ b/backend/server.py
@@ -79,7 +79,9 @@ async def check_submission(websocket:object, submission:dict):
     # Grade the submission inside the docker container "badkan"
     grade = None
     move_command = "mv grading_files/* . && rm -rf grading_files"
-    grade_command = "timeout -s 9 10 timeout 5 nice -n 5 ./grade {} {}".format(username,repository)
+    TIMEOUT_SOFT = 10 # seconds
+    TIMEOUT_HARD = 20 # seconds
+    grade_command = "timeout -s 9 {} timeout {} nice -n 5 ./grade {} {}".format(TIMEOUT_HARD, TIMEOUT_SOFT, username,repository)
     combined_command = "{} && {}".format(move_command, grade_command)
     proc = await docker_command(["exec", "-w", repository_folder, "badkan", "bash", "-c", combined_command])
 


### PR DESCRIPTION
I found a way to add timeout to the docker command. It tries to kill it after 10 seconds, and if it does not succeed, tries harder after 20 seconds. 
This may help to prevent infinite loops by the students. But, as you found out, there is another problem with the frontend even when there is no infinite loop. So we also have to install Apache.